### PR TITLE
Added check for non-empty package.json files

### DIFF
--- a/lua/package-info/modules/core/init.lua
+++ b/lua/package-info/modules/core/init.lua
@@ -1,7 +1,7 @@
 -- FILE DESCRIPTION: Core module entry point
 
-local hide = require('package-info.modules.core.hide')
-local show = require('package-info.modules.core.show')
+local hide = require("package-info.modules.core.hide")
+local show = require("package-info.modules.core.show")
 
 local M = {}
 

--- a/lua/package-info/modules/core/show.lua
+++ b/lua/package-info/modules/core/show.lua
@@ -12,16 +12,15 @@ local utils = require("package-info.utils")
 ---------------------------------- HELPERS ---------------------------------
 ----------------------------------------------------------------------------
 
--- Checks if opened buffer is package.json file
-local check_if_package_json = function()
+-- Checks if the open buffer refers to a non-empty package.json file
+local is_valid_package_json = function()
     local current_buffer_name = vim.api.nvim_buf_get_name(0)
-    local result = string.match(current_buffer_name, "package.json$")
-
-    if result then
-        return true
-    end
-
-    return false
+		-- Check name
+		local is_package_json = string.match(current_buffer_name, "package.json$")
+		-- Check if empty
+		local buffer_size = vim.fn.getfsize(current_buffer_name)
+		-- Ensure package.json is non-empty
+		return is_package_json and buffer_size > 0
 end
 
 -- Determine if package is outdated and return meta about it accordingly
@@ -48,9 +47,8 @@ local get_package_metadata = function(current_package_version, outdated_dependen
 end
 
 local set_virtual_text = function(dependencies, outdated_dependencies)
-    local is_file_package_json = check_if_package_json()
-
-    if not is_file_package_json then
+    -- may be an unnecessary check
+		if not is_valid_package_json() then
         return
     end
 
@@ -101,15 +99,15 @@ end
 
 -- Contains functionality needed in order to set the virtual text
 return function()
-    local is_file_package_json = check_if_package_json()
+		if not is_valid_package_json() then
+				return
+		end
 
-    if is_file_package_json then
-        local dev_dependencies, prod_dependencies, peer_dependencies = utils.buffer.get_dependencies()
+		local dev_dependencies, prod_dependencies, peer_dependencies = utils.buffer.get_dependencies()
 
-        get_outdated_dependencies(function(outdated_dependencies)
-            set_virtual_text(dev_dependencies, outdated_dependencies)
-            set_virtual_text(prod_dependencies, outdated_dependencies)
-            set_virtual_text(peer_dependencies, outdated_dependencies)
-        end)
-    end
+		get_outdated_dependencies(function(outdated_dependencies)
+				set_virtual_text(dev_dependencies, outdated_dependencies)
+				set_virtual_text(prod_dependencies, outdated_dependencies)
+				set_virtual_text(peer_dependencies, outdated_dependencies)
+		end)
 end

--- a/lua/package-info/modules/core/show.lua
+++ b/lua/package-info/modules/core/show.lua
@@ -15,11 +15,9 @@ local utils = require("package-info.utils")
 -- Checks if the open buffer refers to a non-empty package.json file
 local is_valid_package_json = function()
     local current_buffer_name = vim.api.nvim_buf_get_name(0)
-		-- Check name
 		local is_package_json = string.match(current_buffer_name, "package.json$")
-		-- Check if empty
 		local buffer_size = vim.fn.getfsize(current_buffer_name)
-		-- Ensure package.json is non-empty
+
 		return is_package_json and buffer_size > 0
 end
 
@@ -47,7 +45,6 @@ local get_package_metadata = function(current_package_version, outdated_dependen
 end
 
 local set_virtual_text = function(dependencies, outdated_dependencies)
-    -- may be an unnecessary check
 		if not is_valid_package_json() then
         return
     end

--- a/lua/package-info/modules/core/show.lua
+++ b/lua/package-info/modules/core/show.lua
@@ -15,10 +15,10 @@ local utils = require("package-info.utils")
 -- Checks if the open buffer refers to a non-empty package.json file
 local is_valid_package_json = function()
     local current_buffer_name = vim.api.nvim_buf_get_name(0)
-		local is_package_json = string.match(current_buffer_name, "package.json$")
-		local buffer_size = vim.fn.getfsize(current_buffer_name)
+    local is_package_json = string.match(current_buffer_name, "package.json$")
+    local buffer_size = vim.fn.getfsize(current_buffer_name)
 
-		return is_package_json and buffer_size > 0
+    return is_package_json and buffer_size > 0
 end
 
 -- Determine if package is outdated and return meta about it accordingly
@@ -45,7 +45,7 @@ local get_package_metadata = function(current_package_version, outdated_dependen
 end
 
 local set_virtual_text = function(dependencies, outdated_dependencies)
-		if not is_valid_package_json() then
+    if not is_valid_package_json() then
         return
     end
 
@@ -96,15 +96,15 @@ end
 
 -- Contains functionality needed in order to set the virtual text
 return function()
-		if not is_valid_package_json() then
-				return
-		end
+    if not is_valid_package_json() then
+        return
+    end
 
-		local dev_dependencies, prod_dependencies, peer_dependencies = utils.buffer.get_dependencies()
+    local dev_dependencies, prod_dependencies, peer_dependencies = utils.buffer.get_dependencies()
 
-		get_outdated_dependencies(function(outdated_dependencies)
-				set_virtual_text(dev_dependencies, outdated_dependencies)
-				set_virtual_text(prod_dependencies, outdated_dependencies)
-				set_virtual_text(peer_dependencies, outdated_dependencies)
-		end)
+    get_outdated_dependencies(function(outdated_dependencies)
+        set_virtual_text(dev_dependencies, outdated_dependencies)
+        set_virtual_text(prod_dependencies, outdated_dependencies)
+        set_virtual_text(peer_dependencies, outdated_dependencies)
+    end)
 end

--- a/lua/package-info/modules/manager/delete.lua
+++ b/lua/package-info/modules/manager/delete.lua
@@ -8,7 +8,6 @@ local utils = require("package-info.utils")
 ---------------------------------- HELPERS ---------------------------------
 ----------------------------------------------------------------------------
 
-
 local DELETE_ACTIONS = {
     confirm = "Confirm",
     cancel = "Cancel",


### PR DESCRIPTION
Issue:
- Newly created package.json files are not valid json, resulting in the json parser raising the following error:

![package_error](https://user-images.githubusercontent.com/62098008/129080025-9ed04f09-5929-40b5-a729-a85d195f1f3c.png)

Changes:
- Added an additional check to ensure package.json files are non-empty