### PR TITLE
Fix fail parse json when receive partial lines

### DIFF
--- a/lua/package-info/api.lua
+++ b/lua/package-info/api.lua
@@ -2,22 +2,29 @@ local json_parser = require("package-info.libs.json_parser")
 
 local M = {}
 
+local done = false -- TODO: Create issue
+
 -- Get latest version for a given package
 function M:get_outdated_dependencies(callback)
+    local string_value = ""
     local command = "npm outdated --json"
-    local done = false -- TODO: Create issue
 
     vim.fn.jobstart(command, {
         on_stdout = function(_, stdout)
-            if done == false then
-                local string_value = table.concat(stdout)
-                local json_value = json_parser.decode(string_value)
+            local partial_string_value = table.concat(stdout)
+            string_value = string_value .. partial_string_value
+        end,
 
+        on_exit = function(_, __, ___)
+            if done == false then
+                local json_value = json_parser.decode(string_value)
                 callback(json_value)
+                local string_value = ""
             end
 
             done = true
         end,
+
         on_stderr = function(_, stderr)
             if stderr[0] ~= nil then
                 vim.api.nvim_echo({ { "Package info retrieval failed.", "WarningMsg" } }, {}, {})


### PR DESCRIPTION
Neovim's jobstart may receive partial lines, so `on_stdout` may fail to parse JSON.
Able to avoid the parsing error by merging the rows and processing them with `on_exit`.

https://neovim.io/doc/user/job_control.html

```
  Note 2:
	Job event handlers may receive partial (incomplete) lines. For a given
	invocation of on_stdout/on_stderr, `a:data` is not guaranteed to end
	with a newline.
	  - `abcdefg` may arrive as `['abc']`, `['defg']`.
	  - `abc\nefg` may arrive as `['abc', '']`, `['efg']` or `['abc']`,
	    `['','efg']`, or even `['ab']`, `['c','efg']`.
	Easy way to deal with this: initialize a list as `['']`, then append
	to it as follows:
	  let s:chunks = ['']
	  func! s:on_stdout(job_id, data, event) dict
	    let s:chunks[-1] .= a:data[0]
	    call extend(s:chunks, a:data[1:])
	  endf
```