### PR TITLE
save view before reload

### DIFF
--- a/lua/package-info/modules/core.lua
+++ b/lua/package-info/modules/core.lua
@@ -174,7 +174,9 @@ M.__reload_buffer = function()
     local current_buffer_number = vim.fn.bufnr()
 
     if current_buffer_number == config.state.buffer.id then
+        local view = vim.fn.winsaveview()
         vim.cmd(":e")
+        vim.fn.winrestview(view)
     end
 end
 


### PR DESCRIPTION
This adds a save/restore view before it reloads the buffer. 


Before:


https://user-images.githubusercontent.com/2835826/139514262-4216e714-cade-4ce0-ad5e-62e83eae2585.mov



After:


https://user-images.githubusercontent.com/2835826/139514275-458f5a89-e7ff-4dbe-bf2c-0aa7cdc821fc.mov



It's a small change, but a nice quality of life improvement 🙂