### PR TITLE
feat: support pnpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="https://github.com/vuki656/vuki656/blob/master/media/package-info/logo.png" width=315>
 
-## All the `npm`/`yarn` commands I don't want to type
+## All the `npm`/`yarn`/`pnpm` commands I don't want to type
 
 </div>
 
@@ -70,7 +70,7 @@ vim.api.nvim_set_keymap(
 
 <img src="https://github.com/vuki656/vuki656/blob/master/media/package-info/delete.gif" width=500>
 
-Runs `yarn remove` or `npm uninstall` in the background and reloads the buffer.
+Runs `yarn remove`, `npm uninstall`, or `pnpm uninstall` in the background and reloads the buffer.
 
 </div>
 
@@ -91,7 +91,7 @@ vim.api.nvim_set_keymap(
 
 <img src="https://github.com/vuki656/vuki656/blob/master/media/package-info/change.gif" width=500>
 
-Runs `npm install package@version` or `yarn upgrade package@version` in the background and reloads the buffer.
+Runs `npm install package@version`, `yarn upgrade package@version`, or `pnpm update package` in the background and reloads the buffer.
 
 </div>
 
@@ -112,7 +112,7 @@ vim.api.nvim_set_keymap(
 
 <img src="https://github.com/vuki656/vuki656/blob/master/media/package-info/install.gif" width=500>
 
-Runs `npm install package` or `yarn add package` in the background and reloads the buffer.
+Runs `npm install package`, `yarn add package`, or `pnpm add package` in the background and reloads the buffer.
 
 </div>
 
@@ -133,7 +133,7 @@ vim.api.nvim_set_keymap(
 
 <img src="https://github.com/vuki656/vuki656/blob/master/media/package-info/reinstall.gif" width=500>
 
-Runs `rm -rf node_modules && yarn` or `rm -rf node_modules && npm install` in the background and reloads the buffer.
+Runs `rm -rf node_modules && yarn`, `rm -rf node_modules && npm install`, or `rm -rf node_modules && pnpm install` in the background and reloads the buffer.
 
 </div>
 
@@ -230,7 +230,7 @@ require('package-info').setup()
     autostart = true -- Whether to autostart when `package.json` is opened
     hide_up_to_date = true -- It hides up to date versions when displaying virtual text
     hide_unstable_versions = false, -- It hides unstable versions from version list e.g next-11.1.3-canary3
-    -- Can be `npm` or `yarn`. Used for `delete`, `install` etc...
+    -- Can be `npm`, `yarn`, or `pnpm`. Used for `delete`, `install` etc...
     -- The plugin will try to auto-detect the package manager based on
     -- `yarn.lock` or `package-lock.json`. If none are found it will use the
     -- provided one, if nothing is provided it will use `yarn`

--- a/lua/package-info/config.lua
+++ b/lua/package-info/config.lua
@@ -67,6 +67,7 @@ M.state = {
 M.__detect_package_manager = function()
     local package_lock = io.open("package-lock.json", "r")
     local yarn_lock = io.open("yarn.lock", "r")
+    local pnpm_lock = io.open("pnpm-lock.yaml", "r")
 
     if package_lock ~= nil then
         M.options.package_manager = constants.PACKAGE_MANAGERS.npm
@@ -76,6 +77,11 @@ M.__detect_package_manager = function()
     if yarn_lock ~= nil then
         M.options.package_manager = constants.PACKAGE_MANAGERS.yarn
         io.close(yarn_lock)
+    end
+
+    if pnpm_lock ~= nil then
+        M.options.package_manager = constants.PACKAGE_MANAGERS.pnpm
+        io.close(pnpm_lock)
     end
 end
 

--- a/lua/package-info/constants.lua
+++ b/lua/package-info/constants.lua
@@ -10,6 +10,7 @@ M.HIGHLIGHT_GROUPS = {
 M.PACKAGE_MANAGERS = {
     yarn = "yarn",
     npm = "npm",
+    pnpm = "pnpm",
 }
 
 M.DEPENDENCY_TYPE = {

--- a/lua/package-info/tests/utils_spec.lua
+++ b/lua/package-info/tests/utils_spec.lua
@@ -42,6 +42,52 @@ describe("Command retrieval for yarn", function()
     end)
 end)
 
+describe("Command retrieval for pnpm", function()
+    config.options.package_manager = "pnpm"
+
+    it("should get the delete command", function()
+        local command = utils.get_command.delete("prettier")
+
+        assert.are.equals("pnpm remove prettier", command)
+    end)
+
+    it("should get the update command", function()
+        local command = utils.get_command.update("prettier")
+
+        assert.are.equals("pnpm update prettier", command)
+    end)
+
+    it("should get the development install command", function()
+        local command = utils.get_command.install(constants.DEPENDENCY_TYPE.development, "prettier")
+
+        assert.are.equals("pnpm add -D prettier", command)
+    end)
+
+    it("should get the production install command", function()
+        local command = utils.get_command.install(constants.DEPENDENCY_TYPE.production, "prettier")
+
+        assert.are.equals("pnpm add prettier", command)
+    end)
+
+    it("should get the reinstall command", function()
+        local command = utils.get_command.reinstall()
+
+        assert.are.equals("rm -rf node_modules && pnpm install", command)
+    end)
+
+    it("should get the change version command", function()
+        local command = utils.get_command.change_version("prettier", "3.0.0")
+
+        assert.are.equals("pnpm add prettier@3.0.0", command)
+    end)
+
+    it("should get the list command", function()
+        local command = utils.get_command.version_list("prettier")
+
+        assert.are.equals("pnpm view prettier versions --json", command)
+    end)
+end)
+
 describe("Command retrieval for npm", function()
     config.options.package_manager = "npm"
 

--- a/lua/package-info/utils.lua
+++ b/lua/package-info/utils.lua
@@ -122,6 +122,10 @@ M.get_command = {
         if config.options.package_manager == constants.PACKAGE_MANAGERS.npm then
             return "npm uninstall " .. package_name
         end
+
+        if config.options.package_manager == constants.PACKAGE_MANAGERS.pnpm then
+            return "pnpm remove " .. package_name
+        end
     end,
 
     --- Returns the update command based on package manager
@@ -133,6 +137,10 @@ M.get_command = {
 
         if config.options.package_manager == constants.PACKAGE_MANAGERS.npm then
             return "npm install " .. package_name .. "@latest"
+        end
+
+        if config.options.package_manager == constants.PACKAGE_MANAGERS.pnpm then
+            return "pnpm update " .. package_name
         end
     end,
 
@@ -148,6 +156,10 @@ M.get_command = {
             if config.options.package_manager == constants.PACKAGE_MANAGERS.npm then
                 return "npm install --save-dev " .. package_name
             end
+
+            if config.options.package_manager == constants.PACKAGE_MANAGERS.pnpm then
+                return "pnpm add -D " .. package_name
+            end
         end
 
         if type == constants.DEPENDENCY_TYPE.production then
@@ -157,6 +169,10 @@ M.get_command = {
 
             if config.options.package_manager == constants.PACKAGE_MANAGERS.npm then
                 return "npm install " .. package_name
+            end
+
+            if config.options.package_manager == constants.PACKAGE_MANAGERS.pnpm then
+                return "pnpm add " .. package_name
             end
         end
     end,
@@ -169,6 +185,10 @@ M.get_command = {
 
         if config.options.package_manager == constants.PACKAGE_MANAGERS.npm then
             return "rm -rf node_modules && npm install"
+        end
+
+        if config.options.package_manager == constants.PACKAGE_MANAGERS.pnpm then
+            return "rm -rf node_modules && pnpm install"
         end
     end,
 
@@ -183,11 +203,19 @@ M.get_command = {
         if config.options.package_manager == constants.PACKAGE_MANAGERS.npm then
             return "npm install " .. package_name .. "@" .. version
         end
+
+        if config.options.package_manager == constants.PACKAGE_MANAGERS.pnpm then
+            return "pnpm add " .. package_name .. "@" .. version
+        end
     end,
 
     --- Returns available package versions
     -- @param package_name - string used to denote the package
     version_list = function(package_name)
+        if config.options.package_manager == constants.PACKAGE_MANAGERS.pnpm then
+            return "pnpm view " .. package_name .. " versions --json"
+        end
+
         return "npm view " .. package_name .. " versions --json"
     end,
 


### PR DESCRIPTION
Hello! This PR adds support for pnpm, I believe I've covered all the places where changes are necessary but let me know if I missed anything. I've tested every command except `change_version` because I'm running into issues with that, I believe they're unrelated because it looks like it's creating two version select windows or something like that, not sure, but more research is required before I open an issue for that.

Closes #76. As I mentioned in that issue, we can just use `npm outdated --json` to check outdated, since pnpm doesn't support it yet, but we should keep an eye on the issue  in the pnpm repo and probably allow it to use pnpm when it's supported.