### PR TITLE
fix: use on_exit callback to handle finished job

### DIFF
--- a/lua/package-info/modules/core.lua
+++ b/lua/package-info/modules/core.lua
@@ -26,6 +26,7 @@ M.__get_outdated_dependencies = function(callback)
         json = true,
         command = utils.get_command.outdated(),
         on_success = callback,
+        ignore_error = true,
     })
 end
 

--- a/lua/package-info/utils.lua
+++ b/lua/package-info/utils.lua
@@ -73,7 +73,9 @@ M.job = function(options)
         on_exit = function(_, exit_code)
             if exit_code ~= 0 then
                 logger.error("Error running " .. options.command .. ". Try running manually.")
-                options.on_error()
+                if options.on_error ~= nil then
+                    options.on_error()
+                end
 
                 return
             end

--- a/lua/package-info/utils.lua
+++ b/lua/package-info/utils.lua
@@ -12,19 +12,6 @@ local config = require("package-info.config")
 
 M = {}
 
---- Checks if given string contains "error"
--- For now probably acceptable, but should be more precise
--- @param value - string to check
-M.has_errors = function(value)
-    local string_value = value
-
-    if type(value) ~= "string" then
-        string_value = table.concat(value)
-    end
-
-    return string.find(string_value, "error") ~= nil
-end
-
 --- Manages loading animation state
 M.loading = {
     animation = {
@@ -77,35 +64,30 @@ M.loading = {
 --- Runs an async job
 -- @param options.command - string command to run
 -- @param options.json - boolean if output should be parsed as json
--- @param options.callback - function to invoke with the results
+-- @param options.on_success - function to invoke with the results
+-- @param options.on_error - function to invoke if the command fails
 M.job = function(options)
     local value = ""
 
     vim.fn.jobstart(options.command, {
-        on_stdout = function(_, stdout)
-            value = value .. table.concat(stdout)
+        on_exit = function(_, exit_code)
+            if exit_code ~= 0 then
+                logger.error("Error running " .. options.command .. ". Try running manually.")
+                options.on_error()
 
-            if table.concat(stdout) == "" then
-                local has_error = M.has_errors(stdout)
+                return
+            end
 
-                if has_error then
-                    logger.error("Error running " .. options.command .. ". Try running manually.")
+            if options.json then
+                local json_value = json_parser.decode(value)
 
-                    options.on_error(stdout)
-
-                    return
-                end
-
-                if options.json then
-                    local json_value = json_parser.decode(value)
-
-                    options.on_success(json_value)
-
-                    return
-                end
-
+                options.on_success(json_value)
+            else
                 options.on_success(value)
             end
+        end,
+        on_stdout = function(_, stdout)
+            value = value .. table.concat(stdout)
         end,
     })
 end

--- a/lua/package-info/utils.lua
+++ b/lua/package-info/utils.lua
@@ -82,9 +82,16 @@ M.job = function(options)
             end
 
             if options.json then
-                local json_value = json_parser.decode(value)
+                local ok, json_value = pcall(json_parser.decode, value)
 
-                options.on_success(json_value)
+                if ok then
+                    options.on_success(json_value)
+                else
+                    logger.error("Error running " .. options.command .. ". Try running manually.")
+                    if options.on_error ~= nil then
+                        options.on_error()
+                    end
+                end
             else
                 options.on_success(value)
             end

--- a/lua/package-info/utils.lua
+++ b/lua/package-info/utils.lua
@@ -66,12 +66,13 @@ M.loading = {
 -- @param options.json - boolean if output should be parsed as json
 -- @param options.on_success - function to invoke with the results
 -- @param options.on_error - function to invoke if the command fails
+-- @param options.ignore_error - ignore non-zero exit codes
 M.job = function(options)
     local value = ""
 
     vim.fn.jobstart(options.command, {
         on_exit = function(_, exit_code)
-            if exit_code ~= 0 then
+            if exit_code ~= 0 and not options.ignore_error then
                 logger.error("Error running " .. options.command .. ". Try running manually.")
                 if options.on_error ~= nil then
                     options.on_error()


### PR DESCRIPTION
Closes #86.

This is the PR I mentioned in #91. Instead of checking for an empty final line before assuming a process has finished, this uses the `on_exit` callback, which also provides the process's exit code, so we don't have to manually check standard out for strings that look like errors. Using this approach means the `has_errors` helper is no longer necessary, so I think it's OK to remove it as I don't see any other references to it.