### PR TITLE
fix: remove reloads in show command

### DIFF
--- a/lua/package-info/modules/core.lua
+++ b/lua/package-info/modules/core.lua
@@ -270,7 +270,6 @@ M.show = function(options)
 
     if config.state.last_run.should_skip() and options.force == false then
         M.__display_virtual_text()
-        M.__reload()
 
         return
     end
@@ -280,7 +279,6 @@ M.show = function(options)
     M.__get_outdated_dependencies(function(outdated_dependencies)
         M.__parse_buffer()
         M.__display_virtual_text(outdated_dependencies)
-        M.__reload()
 
         utils.loading.stop()
 


### PR DESCRIPTION
As far as I can tell, we don't need to reload the buffer after the show command, because checking for outdated packages should never modify the package.json file. When autostart is enabled, at least with my configuration, I run into situations where reloading the buffer triggers the autostart again and it loops, triggering itself multiple times, so this resolves that.

Closes #90.