### PR TITLE
Fix(#126): only run the autocmd on BufEnter of a package.json

### DIFF
--- a/lua/package-info/actions/show.lua
+++ b/lua/package-info/actions/show.lua
@@ -14,7 +14,6 @@ local M = {}
 M.run = function(options)
     if not state.is_loaded then
         logger.warn("Not in valid package.json file")
-
         return
     end
 

--- a/lua/package-info/config.lua
+++ b/lua/package-info/config.lua
@@ -95,14 +95,14 @@ end
 --- Register autocommand for loading the plugin
 -- @return nil
 M.__register_start = function()
-    register_autocmd("BufEnter", "lua require('package-info.core').load_plugin()")
+    register_autocmd("BufEnter", "*", "lua require('package-info.core').load_plugin()")
 end
 
 --- Register autocommand for auto-starting plugin
 -- @return nil
 M.__register_autostart = function()
     if M.options.autostart then
-        register_autocmd("BufEnter", "lua require('package-info').show()")
+        register_autocmd("BufEnter", "package.json", "lua require('package-info').show()")
     end
 end
 
@@ -118,7 +118,7 @@ M.__register_colorscheme_initialization = function()
         return
     end
 
-    register_autocmd("ColorScheme", "lua require('package-info.config').__register_highlight_groups()")
+    register_autocmd("ColorScheme", "*", "lua require('package-info.config').__register_highlight_groups()")
 end
 
 --- Register all highlight groups

--- a/lua/package-info/utils/register-autocmd.lua
+++ b/lua/package-info/utils/register-autocmd.lua
@@ -1,11 +1,14 @@
 local constants = require("package-info.utils.constants")
+local group = vim.api.nvim_create_augroup(constants.AUTOGROUP, { clear = true })
 
---- Register given command when the event fires
--- @param event: string - event that will trigger the autocommand
--- @param command: string - command to fire when the event is triggered
-return function(event, command)
-    vim.cmd("augroup " .. constants.AUTOGROUP)
-    vim.cmd("autocmd!")
-    vim.cmd("autocmd " .. event .. " * " .. command)
-    vim.cmd("augroup end")
+---Register given command when the event fires
+---@param event string: event that will trigger the autocommand
+---@param pattern string|array: pattern(s) that need to be fulfilled for the `autocmd` to trigger
+---@param command string: command to fire when the event is triggered
+return function(event, pattern, command)
+    vim.api.nvim_create_autocmd(event, {
+        pattern = pattern,
+        group = group,
+        command = command,
+    })
 end


### PR DESCRIPTION
This fixes the issue that I just created. This only runs the auto-command whenever a buffer named `package.json` is actually opened. This prevents the command from being ran on every single buffer that is opened. Due to this, I have reset the branch a commit back. You had created a commit right after I created the issue, and what you did is not needed after this new fix. The message can actually be printed, because the only chance it would ever have at being printed is whenever the correct file is opened.