### PR TITLE
fix: force checktime to autoread package.json

### DIFF
--- a/lua/package-info/helpers/reload.lua
+++ b/lua/package-info/helpers/reload.lua
@@ -8,10 +8,8 @@ local reload_buffer = function()
     local current_buffer_number = vim.fn.bufnr()
 
     if current_buffer_number == state.buffer.id then
-        local view = vim.fn.winsaveview()
-
-        vim.cmd("edit")
-        vim.fn.winrestview(view)
+        vim.bo.autoread = true
+        vim.cmd(":checktime")
     end
 end
 


### PR DESCRIPTION
This is resolve the conflicts of #122 

Note that I cannot see if it's working because the plugin itself it's not working as I said here #127 