### PR TITLE
Change augroup and autocmd handling

### DIFF
--- a/lua/package-info/actions/update.lua
+++ b/lua/package-info/actions/update.lua
@@ -28,7 +28,7 @@ M.__get_command = function(dependency_name)
     end
 
     if config.options.package_manager == constants.PACKAGE_MANAGERS.pnpm then
-        return "pnpm update " .. dependency_name
+        return "pnpm update --latest " .. dependency_name
     end
 end
 

--- a/lua/package-info/config.lua
+++ b/lua/package-info/config.lua
@@ -92,6 +92,14 @@ M.__register_user_options = function(user_options)
     M.options = vim.tbl_deep_extend("keep", user_options or {}, M.__DEFAULT_OPTIONS)
 end
 
+--- Prepare a clean augroup for the plugin to use
+-- @return nil
+M.__prepare_augroup = function()
+    vim.cmd("augroup " .. constants.AUTOGROUP)
+    vim.cmd("autocmd!")
+    vim.cmd("augroup end")
+end
+
 --- Register autocommand for loading the plugin
 -- @return nil
 M.__register_start = function()
@@ -161,6 +169,7 @@ M.setup = function(user_options)
 
     M.__register_package_manager()
     M.__register_namespace()
+    M.__prepare_augroup()
     M.__register_start()
     M.__register_colorscheme_initialization()
     M.__register_autostart()

--- a/lua/package-info/parser.lua
+++ b/lua/package-info/parser.lua
@@ -8,12 +8,8 @@ M.parse_buffer = function()
     local buffer_lines = vim.api.nvim_buf_get_lines(state.buffer.id, 0, -1, false)
     local buffer_json_value = json_parser.decode(table.concat(buffer_lines))
 
-    local all_dependencies_json = vim.tbl_extend(
-        "error",
-        {},
-        buffer_json_value["devDependencies"] or {},
-        buffer_json_value["dependencies"] or {}
-    )
+    local all_dependencies_json =
+        vim.tbl_extend("error", {}, buffer_json_value["devDependencies"] or {}, buffer_json_value["dependencies"] or {})
 
     local installed_dependencies = {}
 

--- a/lua/package-info/tests/suites/config/register_autostart_spec.lua
+++ b/lua/package-info/tests/suites/config/register_autostart_spec.lua
@@ -5,7 +5,6 @@ local reset = require("package-info.tests.utils.reset")
 
 describe("Config register_autostart", function()
     before_each(function()
-        config.__prepare_augroup()
         reset.all()
     end)
 

--- a/lua/package-info/tests/suites/config/register_autostart_spec.lua
+++ b/lua/package-info/tests/suites/config/register_autostart_spec.lua
@@ -5,6 +5,7 @@ local reset = require("package-info.tests.utils.reset")
 
 describe("Config register_autostart", function()
     before_each(function()
+        config.__prepare_augroup()
         reset.all()
     end)
 
@@ -13,6 +14,8 @@ describe("Config register_autostart", function()
     end)
 
     it("should register autostart if autostart option is true", function()
+        config.options.autostart = true
+
         config.__register_autostart()
 
         local autocommands = vim.api.nvim_exec("autocmd BufEnter", true)

--- a/lua/package-info/tests/suites/config/register_colorscheme_initialization_spec.lua
+++ b/lua/package-info/tests/suites/config/register_colorscheme_initialization_spec.lua
@@ -6,6 +6,7 @@ local reset = require("package-info.tests.utils.reset")
 
 describe("Config register_colorscheme_initialization", function()
     before_each(function()
+        config.__prepare_augroup()
         reset.all()
     end)
 

--- a/lua/package-info/tests/suites/config/register_colorscheme_initialization_spec.lua
+++ b/lua/package-info/tests/suites/config/register_colorscheme_initialization_spec.lua
@@ -61,12 +61,8 @@ describe("Config register_colorscheme_initialization", function()
         local up_to_date_color = vim.api.nvim_exec("highlight " .. constants.HIGHLIGHT_GROUPS.up_to_date, true)
         local outdated_color = vim.api.nvim_exec("highlight " .. constants.HIGHLIGHT_GROUPS.outdated, true)
 
-        local is_up_to_date_color_registered = string.find(
-            up_to_date_color,
-            constants.LEGACY_COLORS.up_to_date,
-            0,
-            true
-        )
+        local is_up_to_date_color_registered =
+            string.find(up_to_date_color, constants.LEGACY_COLORS.up_to_date, 0, true)
         local is_outdated_color_registered = string.find(outdated_color, constants.LEGACY_COLORS.outdated, 0, true)
 
         assert.is_not_nil(is_outdated_color_registered)

--- a/lua/package-info/tests/suites/config/register_colorscheme_initialization_spec.lua
+++ b/lua/package-info/tests/suites/config/register_colorscheme_initialization_spec.lua
@@ -6,7 +6,6 @@ local reset = require("package-info.tests.utils.reset")
 
 describe("Config register_colorscheme_initialization", function()
     before_each(function()
-        config.__prepare_augroup()
         reset.all()
     end)
 

--- a/lua/package-info/tests/suites/config/register_start_spec.lua
+++ b/lua/package-info/tests/suites/config/register_start_spec.lua
@@ -17,9 +17,8 @@ describe("Config register_start", function()
 
         local autocommands = vim.api.nvim_exec("autocmd BufEnter", true)
 
-        local is_registered = to_boolean(
-            string.find(autocommands, "require('package-info.core').load_plugin()", 0, true)
-        )
+        local is_registered =
+            to_boolean(string.find(autocommands, "require('package-info.core').load_plugin()", 0, true))
 
         assert.is_true(is_registered)
     end)

--- a/lua/package-info/tests/suites/config/register_start_spec.lua
+++ b/lua/package-info/tests/suites/config/register_start_spec.lua
@@ -5,6 +5,7 @@ local reset = require("package-info.tests.utils.reset")
 
 describe("Config register_start", function()
     before_each(function()
+        config.__prepare_augroup()
         reset.all()
     end)
 

--- a/lua/package-info/tests/suites/config/register_start_spec.lua
+++ b/lua/package-info/tests/suites/config/register_start_spec.lua
@@ -5,7 +5,6 @@ local reset = require("package-info.tests.utils.reset")
 
 describe("Config register_start", function()
     before_each(function()
-        config.__prepare_augroup()
         reset.all()
     end)
 

--- a/lua/package-info/tests/utils/reset.lua
+++ b/lua/package-info/tests/utils/reset.lua
@@ -8,15 +8,7 @@ local M = {}
 -- @return nil
 M.config = function()
     config.options = config.__DEFAULT_OPTIONS
-
-    -- Delete all registered autocommands from plugin autogroup
-    local function reset_autocommands()
-        vim.cmd("autocmd! " .. constants.AUTOGROUP)
-    end
-
-    if pcall(reset_autocommands) then
-        reset_autocommands()
-    end
+    config.__prepare_augroup()
 end
 
 -- Reset state state

--- a/lua/package-info/tests/utils/reset.lua
+++ b/lua/package-info/tests/utils/reset.lua
@@ -1,5 +1,4 @@
 local state = require("package-info.state")
-local constants = require("package-info.utils.constants")
 local config = require("package-info.config")
 
 local M = {}

--- a/lua/package-info/utils/register-autocmd.lua
+++ b/lua/package-info/utils/register-autocmd.lua
@@ -4,8 +4,5 @@ local constants = require("package-info.utils.constants")
 -- @param event: string - event that will trigger the autocommand
 -- @param command: string - command to fire when the event is triggered
 return function(event, command)
-    vim.cmd("augroup " .. constants.AUTOGROUP)
-    vim.cmd("autocmd!")
-    vim.cmd("autocmd " .. event .. " * " .. command)
-    vim.cmd("augroup end")
+    vim.cmd("autocmd " .. constants.AUTOGROUP .. " " .. event .. " package.json " .. command)
 end


### PR DESCRIPTION
The pull request slightly changes the timing of the augroup and autocmd creation to avoid clearing of already registered autocmds.

Additionally changed how `pnpm update` is used, so that the update action installs the version fetched from `pnpm outdated`

Intends to fix #127 