### PR TITLE
Use cwd of package.json as working directory for jobs

### DIFF
--- a/lua/package-info/utils/job.lua
+++ b/lua/package-info/utils/job.lua
@@ -24,6 +24,8 @@ return function(props)
     end
 
     vim.fn.jobstart(props.command, {
+        -- Set the directory of the package.json as working directory for the job
+        cwd = string.sub(vim.fn.expand('%:p'), 1, -13),
         on_exit = function(_, exit_code)
             if exit_code ~= 0 and not props.ignore_error then
                 on_error()

--- a/lua/package-info/utils/job.lua
+++ b/lua/package-info/utils/job.lua
@@ -23,9 +23,15 @@ return function(props)
         end
     end
 
+    -- If a package.json file is open, use the directory of the file
+    -- as working directory for the job
+    local cwd = vim.fn.getcwd()
+    if string.sub(vim.fn.expand("%:p"), -12) == "package.json" then
+        cwd = string.sub(vim.fn.expand("%:p"), 1, -13)
+    end
+
     vim.fn.jobstart(props.command, {
-        -- Set the directory of the package.json as working directory for the job
-        cwd = string.sub(vim.fn.expand('%:p'), 1, -13),
+        cwd = cwd,
         on_exit = function(_, exit_code)
             if exit_code ~= 0 and not props.ignore_error then
                 on_error()

--- a/lua/package-info/utils/job.lua
+++ b/lua/package-info/utils/job.lua
@@ -23,11 +23,17 @@ return function(props)
         end
     end
 
-    -- If a package.json file is open, use the directory of the file
-    -- as working directory for the job
+    -- Get the current cwd and use it as the value for
+    -- cwd in case no package.json is open right now
     local cwd = vim.fn.getcwd()
-    if string.sub(vim.fn.expand("%:p"), -12) == "package.json" then
-        cwd = string.sub(vim.fn.expand("%:p"), 1, -13)
+
+    -- Get the path of the opened file if there is one
+    local file_path = vim.fn.expand("%:p")
+
+    -- If the file is a package.json then use the directory
+    -- of the file as value for cwd
+    if string.sub(file_path, -12) == "package.json" then
+        cwd = string.sub(file_path, 1, -13)
     end
 
     vim.fn.jobstart(props.command, {


### PR DESCRIPTION
As the title mentions, the goal of this pull request is to use the directory of the currently opened package.json as the working directory for the package manager jobs. This is useful for projects with a nested folder and package.json structure e.g.

```
/root
    package.json
    /folderA
        package.json
    /folderB
        package.json
```

If you open the project at the root folder, then the plugin right now would only work on the root package.json. With the change the plugin should work on all 3 package.json files.

Feel free to comment on better ways to get the directory path of the package.json file. It also has not been tested on the windows file path structure.