### PR TITLE
feat(clean version): clean ~ from version as well

### DIFF
--- a/lua/package-info/helpers/clean_version.lua
+++ b/lua/package-info/helpers/clean_version.lua
@@ -1,10 +1,10 @@
---- Strips ^ from version
--- @param value: string - value from which to strip ^ from
+--- Strips ^ and ~ from version
+-- @param value: string - value from which to strip ^ and ~ from
 -- @return string?
 return function(value)
     if value == nil then
         return nil
     end
 
-    return value:gsub("%^", "")
+    return value:gsub("%^", ""):gsub("~", "")
 end


### PR DESCRIPTION
Right now the plugin fails to display version information for entries like `"typescript": "~4.7.2"`. The reason is the `~` sign which causes the version validation to fail. This can be fixed be cleaning the sign from the version just like the `^` sign.