### PR TITLE
Feat: Add nvim-notify support

### DIFF
--- a/lua/package-info/actions/change-version.lua
+++ b/lua/package-info/actions/change-version.lua
@@ -59,7 +59,8 @@ M.__display_dependency_version_select = function(version_list, dependency_name)
     dependency_version_select.new({
         version_list = version_list,
         on_submit = function(selected_version)
-            local id = loading.new("|  Installing " .. dependency_name .. "@" .. selected_version)
+            local loading_name = dependency_name .. "@" .. selected_version
+            local id = loading.new("| 󰆓 Installing " .. loading_name)
 
             job({
                 command = M.__get_change_version_command(dependency_name, selected_version),
@@ -69,10 +70,10 @@ M.__display_dependency_version_select = function(version_list, dependency_name)
                 on_success = function()
                     reload()
 
-                    loading.stop(id)
+                    loading.stop(id, "| 󱣪 Installed " .. loading_name .. " successfully", vim.log.levels.INFO)
                 end,
                 on_error = function()
-                    loading.stop(id)
+                    loading.stop(id, "| 󱙃 Failed to install " .. loading_name, vim.log.levels.ERROR)
                 end,
             })
         end,
@@ -120,7 +121,8 @@ M.run = function()
         return
     end
 
-    local id = loading.new("|  Fetching " .. dependency_name .. " versions")
+    local loading_message = "| 󰇚 Fetching latest versions"
+    local id = loading.new(loading_message)
 
     job({
         json = true,
@@ -129,14 +131,14 @@ M.run = function()
             loading.start(id)
         end,
         on_success = function(versions)
-            loading.stop(id)
+            loading.stop(id, loading_message)
 
             local version_list = M.__create_select_items(versions)
 
             M.__display_dependency_version_select(version_list, dependency_name)
         end,
         on_error = function()
-            loading.stop(id)
+            loading.stop(id, loading_message, vim.log.levels.ERROR)
         end,
     })
 end

--- a/lua/package-info/actions/delete.lua
+++ b/lua/package-info/actions/delete.lua
@@ -57,21 +57,25 @@ M.run = function()
                 on_success = function()
                     reload()
 
-                    loading.stop(id)
+                    loading.stop(id, "|  Deleted " .. dependency_name .. " dependency", vim.log.levels.INFO)
                 end,
                 on_error = function()
-                    loading.stop(id)
+                    loading.stop(
+                        id,
+                        "|  Failed to delete " .. dependency_name .. " dependency",
+                        vim.log.levels.ERROR
+                    )
                 end,
             })
         end,
         on_cancel = function()
-            loading.stop(id)
+            loading.stop(id, "|  Canceled deleting " .. dependency_name .. " dependency", vim.log.levels.WARN)
         end,
     })
 
     prompt.open({
         on_error = function()
-            loading.stop(id)
+            loading.stop(id, "|  Failed to delete " .. dependency_name .. " dependency", vim.log.levels.ERROR)
         end,
     })
 end

--- a/lua/package-info/actions/show.lua
+++ b/lua/package-info/actions/show.lua
@@ -26,7 +26,8 @@ M.run = function(options)
         return
     end
 
-    local id = loading.new("| 󰇚 Fetching latest versions")
+    local loading_message = "| 󰇚 Fetching latest versions"
+    local id = loading.new(loading_message)
 
     job({
         json = true,
@@ -44,11 +45,12 @@ M.run = function(options)
                 reload()
             end
 
-            loading.stop(id)
+            loading.stop(id, loading_message)
+
             state.last_run.update()
         end,
         on_error = function()
-            loading.stop(id)
+            loading.stop(id, loading_message, vim.log.levels.ERROR)
         end,
     })
 end

--- a/lua/package-info/ui/generic/loading-status.lua
+++ b/lua/package-info/ui/generic/loading-status.lua
@@ -17,8 +17,13 @@ local M = {
         current_spinner = "",
         index = 1,
         is_running = false,
+        notification = nil,
     },
 }
+
+-- nvim-notify support
+local nvim_notify = pcall(require, "notify")
+local title = "package-info.nvim"
 
 --- Spawn a new loading instance
 -- @param log: string - message to display in the loading status
@@ -28,9 +33,21 @@ M.new = function(message)
         id = math.random(),
         message = message,
         is_ready = false,
+        notification = nil,
     }
 
+    if nvim_notify then
+        instance.notification = vim.notify(message, vim.log.levels.INFO, {
+            title = title,
+            icon = SPINNERS[1],
+            timeout = false,
+            hide_from_history = true,
+        })
+    end
+
     table.insert(M.queue, instance)
+
+    M.update_spinner(message)
 
     return instance.id
 end
@@ -42,14 +59,40 @@ M.start = function(id)
     for _, instance in ipairs(M.queue) do
         if instance.id == id then
             instance.is_ready = true
+            M.state.notification = instance.notification
         end
     end
 end
 
 --- Stop the instance by given id by removing it from the list
 -- @param id: string - id of the instance to stop and remove
+-- @param message: string - message to be displayed
+-- @param level: number - log level
 -- @return nil
-M.stop = function(id)
+M.stop = function(id, message, level)
+    if message == nil then
+        message = ""
+    end
+    if level == nil then
+        level = vim.log.levels.INFO
+    end
+    if nvim_notify and M.state.notification then
+        local level_icon = {
+            [vim.log.levels.INFO] = "󰗠 ",
+            [vim.log.levels.ERROR] = "󰅙 ",
+            [vim.log.levels.WARN] = "  ",
+        }
+
+        local new_notif = vim.notify(message, level, {
+            title = title,
+            icon = level_icon[level],
+            replace = M.state.notification,
+            timeout = 3000,
+        })
+        M.state.notification = new_notif
+        M.state.notification = nil
+    end
+
     local filtered_list = {}
 
     for _, instance in ipairs(M.queue) do
@@ -63,13 +106,19 @@ end
 
 --- Update the spinner instance recursively
 -- @return nil
-M.update_spinner = function()
+M.update_spinner = function(message)
     M.state.current_spinner = SPINNERS[M.state.index]
 
-    M.state.index = M.state.index + 1
+    M.state.index = (M.state.index + 1) % #SPINNERS
 
-    if M.state.index == 10 then
-        M.state.index = 1
+    if nvim_notify and M.state.notification then
+        local new_notif = vim.notify(message, vim.log.levels.INFO, {
+            title = title,
+            hide_from_history = true,
+            icon = M.state.current_spinner,
+            replace = M.state.notification,
+        })
+        M.state.notification = new_notif
     end
 
     vim.fn.timer_start(60, function()
@@ -103,7 +152,7 @@ M.get = function()
     if active_instance and not M.state.is_running then
         M.state.is_running = true
 
-        M.update_spinner()
+        M.update_spinner(active_instance.message)
     end
 
     return active_instance.message

--- a/lua/package-info/utils/logger.lua
+++ b/lua/package-info/utils/logger.lua
@@ -5,7 +5,33 @@ local M = {}
 -- @param highlight_group: string - highlight group to use when printing the message
 -- @return nil
 M.__print = function(message, highlight_group)
-    vim.api.nvim_echo({ { "PackageInfo: " .. message, highlight_group or "" } }, {}, {})
+    if pcall(require, "notify") then
+        if not highlight_group then
+            highlight_group = "InfoMsg"
+        end
+
+        local level = {
+            ["InfoMsg"] = {
+                log_level = vim.log.levels.INFO,
+                log_symbol = "󰗠 ",
+            },
+            ["ErrorMsg"] = {
+                log_level = vim.log.levels.ERROR,
+                log_symbol = "󰅙 ",
+            },
+            ["WarningMsg"] = {
+                log_level = vim.log.levels.WARN,
+                log_symbol = " ",
+            },
+        }
+        vim.notify(message, level[highlight_group].log_level, {
+            title = "package-info.nvim",
+            icon = level[highlight_group].log_symbol,
+            timeout = 3000,
+        })
+    else
+        vim.api.nvim_echo({ { "PackageInfo: " .. message, highlight_group or "" } }, true, {})
+    end
 end
 
 --- Prints an error message


### PR DESCRIPTION
As the title says, this adds support for [nvim-notify](https://github.com/rcarriga/nvim-notify).

The idea so far is to check if nvim-notify is installed, and if it is, we use `vim.notify()` to display the loading status.

I'm not sure how most people use nvim-notify and if they hook `vim.notify = require("notify")` as described [in the README](https://github.com/rcarriga/nvim-notify/blob/5d33f5e371ba6e63d0e1763ddc18cd9832833bc7/README.md#usage).
I personally use it through [noice](https://github.com/folke/noice.nvim) and this implementation works as expected. Maybe someone from #131 can shime in.

Next steps/questions:
- Update docs?
- Should it be configurable? 

[recording_20231005-234247.webm](https://github.com/vuki656/package-info.nvim/assets/33832653/f2bd11ef-5105-4b81-82bd-e3adc6e4e950)

(Kinda cool I received an error message during my recording :smiling_face_with_tear:)

---

Credit to this [snippet](https://github.com/rcarriga/nvim-notify/issues/43#issuecomment-1030604806) which helped a lot to understand how to replace an existing notification

---

Closes #131 