### PR TITLE
Do not try to update buffer if it was removed

### DIFF
--- a/lua/package-info/actions/show.lua
+++ b/lua/package-info/actions/show.lua
@@ -38,12 +38,13 @@ M.run = function(options)
         on_success = function(outdated_dependencies)
             state.dependencies.outdated = outdated_dependencies
 
-            parser.parse_buffer()
-            virtual_text.display()
-            reload()
-
+            if vim.api.nvim_buf_is_valid(state.buffer.id) and vim.api.nvim_buf_is_loaded(state.buffer.id) then
+                parser.parse_buffer()
+                virtual_text.display()
+                reload()
+            end
+            
             loading.stop(id)
-
             state.last_run.update()
         end,
         on_error = function()

--- a/lua/package-info/actions/show.lua
+++ b/lua/package-info/actions/show.lua
@@ -43,7 +43,7 @@ M.run = function(options)
                 virtual_text.display()
                 reload()
             end
-            
+
             loading.stop(id)
             state.last_run.update()
         end,


### PR DESCRIPTION
This fixes a condition where opening a package.json file quickly and closing it before the job is finished, won't result in a an error.