### PR TITLE
Nicer error message for duplicate deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,12 +197,14 @@ require('package-info').setup()
     colors = {
         up_to_date = "#3C4048", -- Text color for up to date dependency virtual text
         outdated = "#d19a66", -- Text color for outdated dependency virtual text
+        invalid = "#ee4b2b", -- Text color for invalid dependency virtual text
     },
     icons = {
         enable = true, -- Whether to display icons
         style = {
             up_to_date = "|  ", -- Icon for up to date dependencies
             outdated = "|  ", -- Icon for outdated dependencies
+            invalid = "|  ", -- Icon for invalid dependencies
         },
     },
     autostart = true, -- Whether to autostart when `package.json` is opened
@@ -226,6 +228,7 @@ require('package-info').setup()
 colors = {
     up_to_date = "237", -- cterm Grey237
     outdated = "173", -- cterm LightSalmon3
+    invalid = "196", -- cterm Red1
 }
 ```
 

--- a/lua/package-info/config.lua
+++ b/lua/package-info/config.lua
@@ -10,12 +10,14 @@ local M = {
         colors = {
             up_to_date = "#3C4048",
             outdated = "#d19a66",
+            invalid = "#ee4b2b",
         },
         icons = {
             enable = true,
             style = {
                 up_to_date = "|  ",
                 outdated = "|  ",
+                invalid = "|  ",
             },
         },
         autostart = true,
@@ -142,6 +144,7 @@ M.__register_highlight_groups = function()
         colors = {
             up_to_date = constants.LEGACY_COLORS.up_to_date,
             outdated = constants.LEGACY_COLORS.outdated,
+            invalid = constants.LEGACY_COLORS.invalid,
         }
     end
 

--- a/lua/package-info/parser.lua
+++ b/lua/package-info/parser.lua
@@ -37,21 +37,22 @@ M.parse_buffer = function()
         vim.tbl_extend("force", {}, buffer_json_value["devDependencies"] or {}, buffer_json_value["dependencies"] or {})
 
     local installed_dependencies = {}
+    local errored_dependencies = {}
 
     for name, version in pairs(all_dependencies_json) do
+        installed_dependencies[name] = {
+            current = clean_version(version),
+        }
         if intersection[name] ~= nil then
-            installed_dependencies[name] = {
-                current = "[ERROR] DEPENDENCY IS DUPLICATED",
-            }
-        else
-            installed_dependencies[name] = {
-                current = clean_version(version),
+            errored_dependencies[name] = {
+                diagnostic = "DUPLICATED",
             }
         end
     end
 
     state.buffer.lines = buffer_lines
     state.dependencies.installed = installed_dependencies
+    state.dependencies.invalid = errored_dependencies
 end
 
 return M

--- a/lua/package-info/state.lua
+++ b/lua/package-info/state.lua
@@ -21,6 +21,11 @@ M.dependencies = {
     --     current: string - current dependency version
     -- }
     installed = {},
+    -- Detected dependencies with issues as a list of
+    -- ["dependency_name"] = {
+    --      diagnostic: string - feedback
+    -- }
+    invalid = {},
 }
 
 M.buffer = {

--- a/lua/package-info/tests/suites/config/register_user_options_spec.lua
+++ b/lua/package-info/tests/suites/config/register_user_options_spec.lua
@@ -17,12 +17,14 @@ describe("Config register_user_options", function()
             colors = {
                 up_to_date = "#ffffff",
                 outdated = "#333333",
+                invalid = "#ff0000",
             },
             icons = {
                 enable = false,
                 style = {
                     up_to_date = "GG",
                     outdated = "NN",
+                    invalid = "",
                 },
             },
             autostart = false,

--- a/lua/package-info/tests/suites/virtual-text/display_on_line_spec.lua
+++ b/lua/package-info/tests/suites/virtual-text/display_on_line_spec.lua
@@ -127,4 +127,26 @@ describe("Virtual_text display_on_line", function()
         assert.are.equals(dependency.version.current, dependency_metadata.version)
         assert.are.equals(constants.HIGHLIGHT_GROUPS.up_to_date, dependency_metadata.group)
     end)
+
+    it("should display error diagnostics", function()
+        local package_json = file.create_package_json({ go = true })
+        local dependency = package_json.dependencies.next
+
+        config.setup()
+        core.load_plugin()
+
+        state.dependencies.invalid = {
+            [dependency.name] = {
+                diagnostic = "BAD",
+            },
+        }
+
+        local dependency_metadata = virtual_text.__display_on_line(dependency.position + 1, dependency.name)
+
+        file.delete(package_json.path)
+
+        assert.are.equals(config.options.icons.style.invalid, dependency_metadata.icon)
+        assert.are.equals("BAD", dependency_metadata.version)
+        assert.are.equals(constants.HIGHLIGHT_GROUPS.invalid, dependency_metadata.group)
+    end)
 end)

--- a/lua/package-info/tests/utils/reset.lua
+++ b/lua/package-info/tests/utils/reset.lua
@@ -17,6 +17,7 @@ M.state = function()
     state.is_virtual_text_displayed = false
     state.dependencies.outdated = {}
     state.dependencies.installed = {}
+    state.dependencies.invalid = {}
     state.buffer.id = nil
     state.buffer.lines = {}
     state.last_run.time = nil

--- a/lua/package-info/utils/constants.lua
+++ b/lua/package-info/utils/constants.lua
@@ -3,6 +3,7 @@ local M = {}
 M.HIGHLIGHT_GROUPS = {
     outdated = "PackageInfoOutdatedVersion",
     up_to_date = "PackageInfoUpToDateVersion",
+    invalid = "PackageInfoInErrorVersion",
 }
 
 M.PACKAGE_MANAGERS = {
@@ -19,6 +20,7 @@ M.DEPENDENCY_TYPE = {
 M.LEGACY_COLORS = {
     up_to_date = "237",
     outdated = "173",
+    invalid = "196",
 }
 
 M.COMMANDS = {

--- a/lua/package-info/virtual_text.lua
+++ b/lua/package-info/virtual_text.lua
@@ -32,6 +32,15 @@ M.__display_on_line = function(line_number, dependency_name)
         }
     end
 
+    local error_dependency = state.dependencies.invalid[dependency_name]
+    if error_dependency then
+        virtual_text = {
+            group = constants.HIGHLIGHT_GROUPS.invalid,
+            icon = config.options.icons.style.invalid,
+            version = error_dependency.diagnostic,
+        }
+    end
+
     if not config.options.icons.enable then
         virtual_text.icon = ""
     end


### PR DESCRIPTION
Follow up to: https://github.com/vuki656/package-info.nvim/pull/156

I apologize @vuki656, I was poking around for another I was going to propose when I noticed this highlight config. Some colors/icons seem like better feedback rather than `[ERROR]`. 

Here's a proposal pr to incorporate `.in_error` dependencies to the state object. Let me know what you think and how I can polish it!