### PR TITLE
fix: detect package manager relative to package.json directory

### DIFF
--- a/lua/package-info/config.lua
+++ b/lua/package-info/config.lua
@@ -41,7 +41,15 @@ end
 -- Check which lock file exists and set package manager accordingly
 -- @return nil
 M.__register_package_manager = function()
-    local yarn_lock = io.open("yarn.lock", "r")
+    -- Obtener el directorio del package.json actual
+    local package_json_dir = vim.fn.expand("%:p:h")
+
+    -- Si no estamos en un package.json, salir
+    if vim.fn.expand("%:t") ~= "package.json" then
+        return
+    end
+
+    local yarn_lock = io.open(package_json_dir .. "/yarn.lock", "r")
 
     if yarn_lock ~= nil then
         M.options.package_manager = constants.PACKAGE_MANAGERS.yarn
@@ -62,29 +70,24 @@ M.__register_package_manager = function()
 
         io.close(yarn_lock)
         state.is_in_project = true
-
         return
     end
 
-    local package_lock = io.open("package-lock.json", "r")
+    local package_lock = io.open(package_json_dir .. "/package-lock.json", "r")
 
     if package_lock ~= nil then
         M.options.package_manager = constants.PACKAGE_MANAGERS.npm
-
         io.close(package_lock)
         state.is_in_project = true
-
         return
     end
 
-    local pnpm_lock = io.open("pnpm-lock.yaml", "r")
+    local pnpm_lock = io.open(package_json_dir .. "/pnpm-lock.yaml", "r")
 
     if pnpm_lock ~= nil then
         M.options.package_manager = constants.PACKAGE_MANAGERS.pnpm
-
         io.close(pnpm_lock)
         state.is_in_project = true
-
         return
     end
 end

--- a/lua/package-info/utils/logger.lua
+++ b/lua/package-info/utils/logger.lua
@@ -3,7 +3,7 @@ local M = {}
 -- Safely attempt to load the config to avoid circular dependency
 local function get_timeout()
     local ok, cfg = pcall(require, "package-info.config")
-    return (ok and cfg.config.options.timeout) or 3000
+    return (ok and cfg.options and cfg.options.timeout) or 3000
 end
 
 --- Prints a message with a given highlight group


### PR DESCRIPTION
## Summary
This PR fixes package manager detection to be relative to the package.json file location.

## Changes
 - Updated package manager detection to search for lock files in the same directory as package.json
 - Fixed config access error in logger timeout retrieval
 - Added validation to ensure detection only runs when editing package.json files

## Motivation
Previously, the plugin would look for lock files in the current working directory, which could cause issues when working with monorepos or projects with multiple package.json files.

- Update package manager detection to search for lock files in the same directory as package.json
- Fix config access error in logger timeout retrieval (cfg.config.options -> cfg.options)
- Add validation to ensure detection only runs when editing package.json files