### PR TITLE
prevent notification from freezing

### DIFF
--- a/lua/package-info/ui/generic/loading-status.lua
+++ b/lua/package-info/ui/generic/loading-status.lua
@@ -125,7 +125,9 @@ M.stop = function(id, message, level)
             table.insert(filtered_list, instance)
         end
     end
-
+    if #filtered_list == 0 then
+        M.reset_state()
+    end
     M.queue = filtered_list
 end
 
@@ -168,6 +170,10 @@ M.get = function()
             return instance.message
         end
     end
+    return ""
+end
+
+M.reset_state = function()
     M.state.is_running = false
     M.state.current_spinner = ""
     M.state.index = 1
@@ -183,7 +189,5 @@ M.get = function()
             })
         end)
     end
-    return ""
 end
-
 return M

--- a/lua/package-info/ui/generic/loading-status.lua
+++ b/lua/package-info/ui/generic/loading-status.lua
@@ -108,13 +108,12 @@ M.stop = function(id, message, level)
             [vim.log.levels.WARN] = "  ",
         }
 
-        local new_notif = vim.notify(message, level, {
+        vim.notify(message, level, {
             title = title,
             icon = level_icon[level],
             replace = M.state.notification,
             timeout = config.options.timeout,
         })
-        M.state.notification = new_notif
         M.state.notification = nil
     end
 


### PR DESCRIPTION
I finally had some time to sit down and figure out #164 only to realize it's been fixed. I saw mention of the notification never disappearing in #165 , so I decided to tackle that at least. Turns out because the timer wasn't cleared up right away after queue was emptied it got one more tick off, leaving us with a frozen loading message forever instead of a nice spinner.