### PR TITLE
fix: wait until we enter a package.json file to register a pkg manager

### DIFF
--- a/lua/package-info/config.lua
+++ b/lua/package-info/config.lua
@@ -175,6 +175,12 @@ M.__register_autostart = function()
     end
 end
 
+--- Register autocommand for detecting package manager on package.json entry
+-- @return nil
+M.__register_package_manager_initialization = function()
+    register_autocmd("BufEnter", "lua require('package-info.config').__register_package_manager()")
+end
+
 --- Sets the plugin colors after the user colorscheme is loaded
 -- @return nil
 M.__register_colorscheme_initialization = function()
@@ -208,9 +214,9 @@ end
 M.setup = function(user_options)
     M.__register_user_options(user_options)
 
-    M.__register_package_manager()
     M.__register_namespace()
     M.__prepare_augroup()
+    M.__register_package_manager_initialization()
     M.__register_start()
     M.__register_colorscheme_initialization()
     M.__register_autostart()


### PR DESCRIPTION
I call setup on nvim startup, so __register_package_manager would always return early because of this check:
```
    -- If we're not in a package.json file, exit
    if vim.fn.expand("%:t") ~= "package.json" then
        return
    end
```
similar to the other register fns, this waits until we actually enter a package.json file